### PR TITLE
fix: resolve TypeScript type-check errors in tests (CI failure)

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -9,8 +9,8 @@
 
 export const E2E_JWT_SECRET = 'e2e-test-jwt-secret-mymicroworkouts';
 
-function base64urlEncode(buf: ArrayBuffer): string {
-  const bytes = new Uint8Array(buf);
+function base64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
   let binary = '';
   for (const b of bytes) binary += String.fromCharCode(b);
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,8 +5,8 @@
 
 const TEST_SECRET = 'test-secret-key-for-vitest-only';
 
-function base64urlEncode(buf: ArrayBuffer): string {
-  const bytes = new Uint8Array(buf);
+function base64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
   let binary = '';
   for (const b of bytes) binary += String.fromCharCode(b);
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');

--- a/tests/workouts.test.ts
+++ b/tests/workouts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { onRequestGet, onRequestPost, onRequestDelete } from '../functions/api/workouts/index';
 import { mintJWT, validPayload, TEST_SECRET } from './helpers';
+import type { Env } from '../src/auth';
 
 // ─── D1 mock factory ───────────────────────────────────────────────────────
 // Mimics the prepare().bind().all() / .first() / .run() chained D1 API.
@@ -40,7 +41,10 @@ async function makeContext(
   });
 
   const db = makeD1Mock(dbOverrides);
-  const env = { DB: db, JWT_SECRET_KEY: TEST_SECRET, AUTH_SIDECAR_URL: '', BASE_URL: '' };
+  // Cast via unknown — the mock only implements the methods under test; the
+  // full D1Database interface has additional methods (batch, exec, etc.) that
+  // are not exercised by the workouts handler.
+  const env = { DB: db, JWT_SECRET_KEY: TEST_SECRET, AUTH_SIDECAR_URL: '', BASE_URL: '' } as unknown as Env;
   return { context: { request, env }, db };
 }
 
@@ -147,7 +151,7 @@ describe('POST /api/workouts', () => {
       body: 'not json',
     });
     const db = makeD1Mock();
-    const env = { DB: db, JWT_SECRET_KEY: TEST_SECRET, AUTH_SIDECAR_URL: '', BASE_URL: '' };
+    const env = { DB: db, JWT_SECRET_KEY: TEST_SECRET, AUTH_SIDECAR_URL: '', BASE_URL: '' } as unknown as Env;
     const res = await onRequestPost({ request, env });
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
Fixes the `type-check` step failure in pipeline #8 on `develop`.

## Root cause

Two TypeScript errors introduced by the stricter `@cloudflare/workers-types` upgrade:

1. `base64urlEncode(buf: ArrayBuffer)` — `TextEncoder.encode()` returns `Uint8Array`, not `ArrayBuffer`. TS5 no longer accepts this implicitly.
2. `makeD1Mock()` in `tests/workouts.test.ts` — the mock object is missing `batch`, `exec`, `withSession`, `dump` from the full `D1Database` interface.

## Fix

- Widened `base64urlEncode` param to `ArrayBuffer | Uint8Array` in `tests/helpers.ts` and `e2e/helpers/auth.ts`
- Added `as unknown as Env` cast on the mock env in `tests/workouts.test.ts`
- Imported `Env` type from `src/auth.ts` in the workouts test

`npx tsc --noEmit` — clean. All 26 unit tests still pass.