### PR TITLE
fix: deploy-frost step — Woodpecker expanding ${VAR} to empty in SSH heredoc

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -114,14 +114,14 @@ steps:
           --name mw-auth-sidecar \
           --restart unless-stopped \
           --link mw-postgres:postgres \
-          -p ${SIDECAR_PORT}:8787 \
-          --env-file ${DEPLOY_DIR}/auth-sidecar/.env \
+          -p $SIDECAR_PORT:8787 \
+          --env-file $DEPLOY_DIR/auth-sidecar/.env \
           mymicroworkouts-auth-sidecar:latest
         sleep 3
         docker logs mw-auth-sidecar --tail 5
 
         # Install npm deps and initialise local D1 database
-        cd ${DEPLOY_DIR}
+        cd $DEPLOY_DIR
         npm install --silent
         rm -rf .wrangler/state/v3/d1
         ./scripts/init-db.sh local 2>&1 | grep -E '(Done|success|✅|✓|error|Error)' || true
@@ -130,7 +130,7 @@ steps:
         pkill -f 'wrangler pages dev' 2>/dev/null || true
         sleep 1
         nohup ./node_modules/.bin/wrangler pages dev public \
-          --ip 0.0.0.0 --port ${APP_PORT} \
+          --ip 0.0.0.0 --port $APP_PORT \
           > /tmp/mymicroworkouts-app.log 2>&1 &
         sleep 3
         echo "=== Wrangler last log lines ==="


### PR DESCRIPTION
Fixes the `deploy-frost` failure in pipeline #12 on `main`.

## Root cause

Woodpecker substitutes `${VAR}` syntax in YAML command strings **before** the shell runs. `${DEPLOY_DIR}`, `${SIDECAR_PORT}`, and `${APP_PORT}` are bash variables set inside the SSH heredoc on frost — they are not Woodpecker environment variables — so Woodpecker expanded them all to empty strings:

- `-p ${SIDECAR_PORT}:8787` → `-p :8787`
- `--env-file ${DEPLOY_DIR}/auth-sidecar/.env` → `--env-file /auth-sidecar/.env` → file not found → `docker run` error

## Fix

Changed `${VAR}` to `$VAR` (no braces) for the three bash-local variables. Woodpecker only substitutes the `${VAR}` form; `$VAR` is passed through verbatim and bash on frost expands it correctly.