### PR TITLE
fix: deploy-frost variable expansion in Woodpecker heredoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 auth-sidecar/.env
 test-results/
 playwright-report/
+git_clean.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 coverage/
 .nyc_output/
 auth-sidecar/.env
+auth-sidecar/jgf-auth/
 test-results/
 playwright-report/
 git_clean.sh

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -114,14 +114,14 @@ steps:
           --name mw-auth-sidecar \
           --restart unless-stopped \
           --link mw-postgres:postgres \
-          -p ${SIDECAR_PORT}:8787 \
-          --env-file ${DEPLOY_DIR}/auth-sidecar/.env \
+          -p $SIDECAR_PORT:8787 \
+          --env-file $DEPLOY_DIR/auth-sidecar/.env \
           mymicroworkouts-auth-sidecar:latest
         sleep 3
         docker logs mw-auth-sidecar --tail 5
 
         # Install npm deps and initialise local D1 database
-        cd ${DEPLOY_DIR}
+        cd $DEPLOY_DIR
         npm install --silent
         rm -rf .wrangler/state/v3/d1
         ./scripts/init-db.sh local 2>&1 | grep -E '(Done|success|✅|✓|error|Error)' || true
@@ -130,7 +130,7 @@ steps:
         pkill -f 'wrangler pages dev' 2>/dev/null || true
         sleep 1
         nohup ./node_modules/.bin/wrangler pages dev public \
-          --ip 0.0.0.0 --port ${APP_PORT} \
+          --ip 0.0.0.0 --port $APP_PORT \
           > /tmp/mymicroworkouts-app.log 2>&1 &
         sleep 3
         echo "=== Wrangler last log lines ==="


### PR DESCRIPTION
Fixes the `deploy-frost` failure from the previous main pipeline (#12).

## Change

`${DEPLOY_DIR}`, `${SIDECAR_PORT}`, `${APP_PORT}` inside the SSH heredoc were being expanded to empty by Woodpecker before the shell ran. Changed to `$VAR` (no braces) so Woodpecker leaves them alone and bash on frost expands them correctly.